### PR TITLE
Fix: Handle Base64 image input from API

### DIFF
--- a/scripts/kontext.py
+++ b/scripts/kontext.py
@@ -1,5 +1,8 @@
 import gradio
 import torch, numpy
+import base64
+import io
+from PIL import Image
 
 from modules import scripts, shared
 from modules.ui_components import InputAccordion, ToolButton
@@ -162,6 +165,17 @@ class forgeKontext(scripts.Script):
                 # extra_mem = 0   # test if useful for large inputs
                 for image in [image1, image2]:
                     if image is not None:
+                        # --- START: ADDED CODE FOR API/Base64 SUPPORT ---
+                        if isinstance(image, str):
+                            try:
+                                # If image is a string, it's Base64 from the API. Decode it.
+                                decoded_image = base64.b64decode(image)
+                                image = Image.open(io.BytesIO(decoded_image))
+                            except Exception as e:
+                                print(f"[Kontext] Error decoding Base64 image from API: {e}")
+                                continue # Skip to the next image if this one is invalid
+                        # --- END: ADDED CODE FOR API/Base64 SUPPORT ---
+
                         k_image = image.convert('RGB')
                         k_image = numpy.array(k_image) / 255.0
                         k_image = numpy.transpose(k_image, (2, 0, 1))


### PR DESCRIPTION
fixes a crash that occurs when sending a Base64 encoded image to the extension via the API..
original code expected a PIL Image object for the image parameter. When called from an API, this parameter is a Base64 string, which caused an AttributeError: 'str' object has no attribute 'convert'.
This change adds a check to see if the image variable is a string. If it is, it decodes the Base64 data into a proper PIL Image object before the rest of the script processes it. This makes the extension compatible with both the standard UI and API calls. Tested using an n8n workflow that sends a Base64 image via the /sdapi/v1/txt2img endpoint. The workflow now completes successfully and the image is used as context.